### PR TITLE
Prevent parallel requests as Lambda RIE does not support it

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,9 @@ This project is mostly useful for people running web frameworks (like Laravel, S
 ### Does this support API Gateway features?
 
 No, this is a very simple HTTP server. It does not support API Gateway features like CORS, authorizers, etc.
+
+### How are parallel requests handled?
+
+The Lambda RIE does not support parallel requests. This project handles them by "queueing" requests. If a request is already being processed, the next request will be queued and processed when the first request is done.
+
+This works up to 10 requests in parallel by default. You can change this limit by setting the `DEV_MAX_REQUESTS_IN_PARALLEL` environment variable.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@aws-sdk/client-lambda": "^3.216.0",
     "express": "^4.18.2",
+    "express-queue": "^0.0.13",
     "node-fetch": "^3.3.0"
   }
 }

--- a/test/manual/Dockerfile
+++ b/test/manual/Dockerfile
@@ -1,0 +1,13 @@
+FROM public.ecr.aws/lambda/provided:al2
+
+# Fake AWS credentials so that the Lambda client works
+ENV AWS_ACCESS_KEY_ID='fake'
+ENV AWS_SECRET_ACCESS_KEY='fake'
+
+# Install node to run the JS app below
+RUN curl --silent --location https://rpm.nodesource.com/setup_16.x | bash -
+RUN yum install --setopt=skip_missing_names_on_install=False -y nodejs
+
+WORKDIR /var/task
+
+EXPOSE 8000

--- a/test/manual/README.md
+++ b/test/manual/README.md
@@ -1,0 +1,13 @@
+This directory let us run the local API Gateway with a fake Lambda handler (written in bash for simplicity).
+
+## How to run
+
+First, compile the project at the project root.
+
+Then move to the test folder:
+
+```bash
+docker compose up
+```
+
+Then either hit http://localhost:8000/ or open [index.html](./index.html) in your browser.

--- a/test/manual/bootstrap.sh
+++ b/test/manual/bootstrap.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+set -euo pipefail
+
+function handler() {
+    EVENT_DATA=$1
+#    echo "$EVENT_DATA" 1>&2;
+    sleep 1
+    RESPONSE='{
+                "statusCode": 200,
+                "body": "Hello world!"
+    }'
+    echo "$RESPONSE"
+}
+
+# Processing
+while true
+do
+    HEADERS="$(mktemp)"
+    # Get an event. The HTTP request will block until one is received
+    EVENT_DATA=$(curl -sS -LD "$HEADERS" -X GET "http://${AWS_LAMBDA_RUNTIME_API}/2018-06-01/runtime/invocation/next")
+
+    # Extract request ID by scraping response headers received above
+    REQUEST_ID=$(grep -Fi Lambda-Runtime-Aws-Request-Id "$HEADERS" | tr -d '[:space:]' | cut -d: -f2)
+
+    # Run the handler function from the script
+    RESPONSE=$(handler "$EVENT_DATA")
+
+    # Send the response
+    curl -s -X POST "http://${AWS_LAMBDA_RUNTIME_API}/2018-06-01/runtime/invocation/$REQUEST_ID/response"  -d "$RESPONSE"
+done

--- a/test/manual/docker-compose.yml
+++ b/test/manual/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.5"
+
+services:
+    app:
+        build:
+            context: .
+        ports: [ '8000:8000' ]
+        volumes:
+            - .:/var/task
+            - ./bootstrap.sh:/var/runtime/bootstrap
+            - ../..:/local-api-gateway
+        entrypoint: /var/task/entrypoint.sh
+        command: [""]

--- a/test/manual/entrypoint.sh
+++ b/test/manual/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+# Run the fake API Gateway
+# (forces fake AWS credentials so that the Lambda client works)
+AWS_ACCESS_KEY_ID='fake' AWS_SECRET_ACCESS_KEY='fake' \
+    TARGET=localhost:8080 \
+    node /local-api-gateway/dist/index.js &
+
+# Run the original AWS Lambda entrypoint (RIE) with the handler argument
+/lambda-entrypoint.sh "handler"

--- a/test/manual/index.html
+++ b/test/manual/index.html
@@ -1,0 +1,14 @@
+<html>
+<head>
+<title>Manual Tests</title>
+</head>
+<body>
+<h1>Test multiple requests in parallel</h1>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.4/jquery.min.js" integrity="sha512-pumBsjNRGGqkPzKHndZMaAG+bir374sORyzM3uulLV14lN5LyykqNk8eEeUlUkB3U0M4FApyaHraT65ihJhDpQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script>
+    jQuery.get('http://localhost:8000/');
+    jQuery.get('http://localhost:8000/');
+    jQuery.get('http://localhost:8000/');
+</script>
+</body>
+</html>


### PR DESCRIPTION
The solution here is to use a request "queue": incoming requests are queued until the previous request is finished.

Addresses https://github.com/brefphp/bref/issues/1471