### PR TITLE
Push multi-arch images (amd64/arm64) into docker hub.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc && docker build -t bref/local-api-gateway .",
-    "docker-publish": "npm run build && docker push bref/local-api-gateway",
+    "build": "tsc && docker buildx build --load -t bref/local-api-gateway .",
+    "docker-publish": "npm run build && docker buildx build --push --platform linux/amd64,linux/arm64/v8 -t bref/local-api-gateway .",
     "lint": "eslint .",
     "test": "vitest"
   },


### PR DESCRIPTION
This uses buildx to build a multi-arch image for pushing into github.

The `build` stage might not make a whole lot of sense now, but it does
build the arch that matches the host and loads it so you could use it
locally. If you invoke `docker-publish` right after it should reuse the
cache for the image for that arch and then proceed to also build the
other, pushing them into the remote registry.

This allows anyone to pull and use this image on both arm64 and amd64
hosts.

For my use case, I want to use this locally on my development laptop, which
is arm64, but I also want to use it to proxy some tests on a github action runner
which is amd64.
