### PR TITLE
Handle binary responses from lambda when `isBase64Encoded` is set

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,7 @@ app.all('*', async (req: Request, res: Response, next) => {
         res.setHeader('Set-Cookie', lambdaResponse.cookies);
     }
 
-    let body = lambdaResponse.body;
+    const body = lambdaResponse.body;
     if (body && lambdaResponse.isBase64Encoded) {
         res.end(Buffer.from(body, 'base64'));
     } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,9 +105,10 @@ app.all('*', async (req: Request, res: Response, next) => {
 
     let body = lambdaResponse.body;
     if (body && lambdaResponse.isBase64Encoded) {
-        body = Buffer.from(body, 'base64').toString('utf-8');
+        res.end(Buffer.from(body, 'base64'));
+    } else {
+        res.end(body);
     }
-    res.send(body);
 });
 
 app.listen(port, () => {


### PR DESCRIPTION
Currently, the translation layer assumes that responses from lambda are strings. This will break when the lambda intentionally respond with a binary data.

This PR adds an explicit handling for this case.