### PR TITLE
Add `x-forwarded-*` headers to upstream lambda request

### DIFF
--- a/src/apiGateway.ts
+++ b/src/apiGateway.ts
@@ -40,7 +40,12 @@ export function httpRequestToEvent(request: Request): APIGatewayProxyEventV2 {
         rawPath: request.path,
         rawQueryString: url.parse(request.originalUrl).query ?? '',
         cookies: request.cookies,
-        headers,
+        headers: {
+            'x-forwarded-proto': request.protocol,
+            'x-forwarded-port': `${request.socket.localPort}`,
+            'x-forwarded-for': request.ip,
+            ...headers,
+        },
         queryStringParameters,
         body: request.body,
         pathParameters: {},

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,7 +111,7 @@ app.all('*', async (req: Request, res: Response, next) => {
     }
 });
 
-const server = app.listen(port, () => {
+export const server = app.listen(port, () => {
     console.log(`⚡️ Server is running at http://localhost:${port}`);
 });
 
@@ -128,5 +128,3 @@ type LambdaInvokeError = {
     errorType: string;
     errorMessage: string;
 };
-
-export default app;

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,3 +128,5 @@ type LambdaInvokeError = {
     errorType: string;
     errorMessage: string;
 };
+
+export default app;

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -33,7 +33,7 @@ describe('server', () => {
             headers: {
                 'accept-encoding': 'gzip, deflate',
                 connection: 'close',
-                'x-forwarded-for': '::ffff:127.0.0.1',
+                'x-forwarded-for': '127.0.0.1',
                 'x-forwarded-port': '8000',
                 'x-forwarded-proto': 'http',
             },
@@ -51,7 +51,7 @@ describe('server', () => {
                     method: 'GET',
                     path: '/',
                     protocol: 'http',
-                    sourceIp: '::ffff:127.0.0.1',
+                    sourceIp: '127.0.0.1',
                     userAgent: '',
                 },
                 requestId: 'id',
@@ -89,7 +89,7 @@ describe('server', () => {
         expect(getEventFromLambdaApiCall(lambda, 0).headers).toStrictEqual({
             'accept-encoding': 'gzip, deflate',
             connection: 'close',
-            'x-forwarded-for': '::ffff:127.0.0.1',
+            'x-forwarded-for': '127.0.0.1',
             'x-forwarded-port': '8000',
             'x-forwarded-proto': 'http',
             'x-my-header': 'foo',

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -5,7 +5,7 @@ import { InvocationResponse, LambdaClient, ServiceInputTypes, ServiceOutputTypes
 
 process.env.TARGET = 'localhost:9000';
 
-import app from '../src/index';
+import { server as app } from '../src/index';
 
 describe('server', () => {
     let lambda: AwsStub<ServiceInputTypes, ServiceOutputTypes>;
@@ -33,6 +33,9 @@ describe('server', () => {
             headers: {
                 'accept-encoding': 'gzip, deflate',
                 connection: 'close',
+                'x-forwarded-for': '::ffff:127.0.0.1',
+                'x-forwarded-port': '8000',
+                'x-forwarded-proto': 'http',
             },
             isBase64Encoded: false,
             pathParameters: {},
@@ -86,6 +89,9 @@ describe('server', () => {
         expect(getEventFromLambdaApiCall(lambda, 0).headers).toStrictEqual({
             'accept-encoding': 'gzip, deflate',
             connection: 'close',
+            'x-forwarded-for': '::ffff:127.0.0.1',
+            'x-forwarded-port': '8000',
+            'x-forwarded-proto': 'http',
             'x-my-header': 'foo',
         });
     });


### PR DESCRIPTION
Lambda event from real API gateway always have these `x-forwarded-*` headers, and some library that translate lambda events for HTTP frameworks expects these.

[Mangum](https://github.com/jordaneremieff/mangum) will default to HTTPS if there's no `x-forwarded-proto` present in the request headers.