### PR TITLE
Make `LISTEN_{ADDRESS,PORT}` configurable via environment variables

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -113,7 +113,7 @@ app.all('*', async (req: Request, res: Response, next) => {
 });
 
 const server = app.listen(port, address, () => {
-    const userFriendlyAddress = address === '0.0.0.0' ? 'localhost' : address;
+    const userFriendlyAddress = address === '0.0.0.0' && !process.env.LISTEN_ADDRESS ? 'localhost' : address;
     console.log(`⚡️ Server is running at http://${userFriendlyAddress}:${port}`);
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,7 +113,8 @@ app.all('*', async (req: Request, res: Response, next) => {
 });
 
 const server = app.listen(port, address, () => {
-    console.log(`⚡️ Server is running at http://${address}:${port}`);
+    const userFriendlyAddress = address === '0.0.0.0' ? 'localhost' : address;
+    console.log(`⚡️ Server is running at http://${userFriendlyAddress}:${port}`);
 });
 
 const shutdown = () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,8 @@ import { InvocationType, InvokeCommand, InvokeCommandOutput, LambdaClient } from
 import { httpRequestToEvent } from './apiGateway';
 
 const app = express();
-const port = 8000;
+const address = process.env.LISTEN_ADDRESS || '0.0.0.0';
+const port = Number(process.env.LISTEN_PORT) || 8000;
 
 if (process.env.DOCUMENT_ROOT) {
     app.use(express.static(process.env.DOCUMENT_ROOT));
@@ -111,8 +112,8 @@ app.all('*', async (req: Request, res: Response, next) => {
     }
 });
 
-const server = app.listen(port, () => {
-    console.log(`⚡️ Server is running at http://localhost:${port}`);
+const server = app.listen(port, address, () => {
+    console.log(`⚡️ Server is running at http://${address}:${port}`);
 });
 
 const shutdown = () => {


### PR DESCRIPTION
This PR adds the ability to configure express to listen on specific address and port via environment variables `LISTEN_ADDRESS` and `LISTEN_PORT`.

If these environment variables are not configured, it will fallback to the default which is the same behavior as current `main` branch.