### PR TITLE
Fixed binary data from form-data not getting converted to base64

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-lambda": "^3.216.0",
+    "body-parser": "^1.20.2",
     "express": "^4.18.2",
     "express-queue": "^0.0.13",
     "node-fetch": "^3.3.0"

--- a/src/apiGateway.ts
+++ b/src/apiGateway.ts
@@ -34,8 +34,8 @@ export function httpRequestToEvent(request: Request): APIGatewayProxyEventV2 {
         }
     );
 
-    const bodyString = request.body.toString('utf8');
-    const shouldSendBase64 = bodyString.includes('Content-Disposition: form-data');
+    const bodyString = request.method === 'GET' ? '' : request.body.toString('utf8');
+    const shouldSendBase64 = request.method === 'GET' ? false : bodyString.includes('Content-Disposition: form-data');
 
     return {
         version: '2.0',

--- a/src/apiGateway.ts
+++ b/src/apiGateway.ts
@@ -34,6 +34,9 @@ export function httpRequestToEvent(request: Request): APIGatewayProxyEventV2 {
         }
     );
 
+    const bodyString = request.body.toString('utf8');
+    const shouldSendBase64 = bodyString.includes('Content-Disposition: form-data');
+
     return {
         version: '2.0',
         routeKey: '$default',
@@ -47,9 +50,9 @@ export function httpRequestToEvent(request: Request): APIGatewayProxyEventV2 {
             ...headers,
         },
         queryStringParameters,
-        body: request.body,
+        body: shouldSendBase64 ? request.body.toString('base64') : bodyString,
         pathParameters: {},
-        isBase64Encoded: false,
+        isBase64Encoded: shouldSendBase64,
         stageVariables: {},
         requestContext: {
             http: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ app.use((err: Error, req: Request, res: Response, next: NextFunction) => {
 });
 
 // Populate `req.body` with the raw body content (buffer).
-// We use a Buffer to avoid issues with binrary data during file upload.
+// We use a Buffer to avoid issues with binary data during file upload.
 // See https://stackoverflow.com/a/18710277/245552
 app.use(bodyParser.raw({
     inflate: true,


### PR DESCRIPTION
This PR resolves https://github.com/brefphp/bref/issues/1537 by not converting request body to UTF8 send form-data requests as base64. It utilize https://www.npmjs.com/package/body-parser as a middleware to get the raw request body as a buffer.

I'm not too sure of the implementation. I feels a bit hackish looking at the raw body to detect form-data requests. Additionally, form-data requests may contain content that can perfectly well be displayed in UTF8 (such as regular form-data or CSV file uploads).

Investigation with a AWS demo setup showed that even CSV uploads gets received in the Lambda as base64 encoded.

I'm wondering if it may be better to simply always send as base64. Unless of course AWS has some documentation hidden some where on how they detect if it should send base64 or not.

Looking for feedback.