### PR TITLE
Add information about LISTEN_PORT

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ services:
             - .:/var/task:ro
 ```
 
+If you need to change the default listening port, you can set the `LISTEN_PORT` environment variable value to whatever port you wish to use.
+
 ## Static assets
 
 If you want a quick and easy way to serve static assets, mount your files in the `bref/local-api-gateway` container and set the `DOCUMENT_ROOT` env var to the root of the assets.


### PR DESCRIPTION
With Bref v1, we used the port `8787` for our stack, but with Bref v2, the default listening port is set to `8000`.

Symfony was redirecting to this port as the `bref/fpm-dev-gateway:1` image used to proxy the requests.

I believe this information should be stated into this page: https://bref.sh/docs/web-apps/local-development.html

