### PR TITLE
Add address/port config example for express

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ services:
         environment:
             # <host>:<port> -> the host here is "php" because that's the name of the second container
             TARGET: 'php:8080'
+            # Binds and listens for connections on the specified host and port. 0.0.0.0:8000 is the defailt configuration.
+            # E.g. you can set LISTEN_PORT to 443 if you have issues to make https requests work.
+            # LISTEN_ADDRESS: '0.0.0.0' 
+            # LISTEN_PORT: 8000
             
     # Example of container running AWS Lambda locally
     php:


### PR DESCRIPTION
We needed to change the internal port to make an https nginx proxy work. After taking a look into the code I saw that it is possible to configure the express server. This was not documented.

https://github.com/brefphp/bref/issues/1692#issuecomment-1818568101
