### PR TITLE
fix: passing body for graphql requests generated from aws-appsync-simulator

### DIFF
--- a/src/apiGateway.ts
+++ b/src/apiGateway.ts
@@ -34,7 +34,7 @@ export function httpRequestToEvent(request: Request): APIGatewayProxyEventV2 {
         }
     );
 
-    const bodyString = request.body.toString('utf8');
+    const bodyString = Buffer.isBuffer(request.body) ? request.body.toString('utf8') : '';
     const shouldSendBase64 = request.method === 'GET' ? false : bodyString.includes('Content-Disposition: form-data');
 
     const cookies = request.headers.cookie ? request.headers.cookie.split('; ') : [];

--- a/src/apiGateway.ts
+++ b/src/apiGateway.ts
@@ -34,7 +34,7 @@ export function httpRequestToEvent(request: Request): APIGatewayProxyEventV2 {
         }
     );
 
-    const bodyString = request.method === 'GET' ? '' : request.body.toString('utf8');
+    const bodyString = request.body.toString('utf8');
     const shouldSendBase64 = request.method === 'GET' ? false : bodyString.includes('Content-Disposition: form-data');
 
     const cookies = request.headers.cookie ? request.headers.cookie.split('; ') : [];
@@ -61,7 +61,7 @@ export function httpRequestToEvent(request: Request): APIGatewayProxyEventV2 {
                 method: request.method,
                 path: request.path,
                 protocol: request.protocol,
-                sourceIp: request.ip,
+                sourceIp: String(request.ip),
                 userAgent: request.header('User-Agent') ?? '',
             },
             accountId: '123456789012',


### PR DESCRIPTION
Hi,

I'm running a local version of AppSync (via `servereless-offline`)+ API Gateway (via this package) + Bref:

```
[ Client ] ---> [ AppSync ] ---> [ HTTP Resolver ] ---> [ API Gateway] ---> [ Bref ]
```

I was finding all of my GraphQL queries and mutations were missing the body part of the request. I looked into it and found `local-api-gateway` was suppressing the body of the request. 

I have removed that conditional in this PR to pass the body whenever it's available, and all is working for my use case now. 

I get the intent of the code, and I suspect it's not working because the payload, at least in my case, has `method` in `request.requestContext.method`, and not `request.method`. But I think it's not terrible to simplify things and just pass body if it's supplied, especially given the aims of this project to be minimally useful.

I also added a tidy on L64 to cast `request.ip` as a string, because the Typescript indicates `request.ip` is `string|null` while the AWS payload must be a `string`.

Note I tried to spin up the tests and contribute a unit test, but I couldn't work out the dev steps to get them going. If you want me to work on some tests, give me some hints on how to get started and I'd be happy to do so.

Thanks, Scott