### PR TITLE
Concurrent execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ FROM node:18-alpine
 ENV AWS_ACCESS_KEY_ID='fake'
 ENV AWS_SECRET_ACCESS_KEY='fake'
 
+# Install Docker CLI
+RUN apk add --no-cache docker-cli
+
 WORKDIR /app
 COPY package.json package.json
 RUN npm install --production

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ services:
     image: bref/local-api-gateway
     ports: ['8000:8000']
     volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
       - .:/var/task:ro
     environment:
       TARGET: 'php:8080' # service:port

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+## Fork
+
+This is a fork of [bref/local-api-gateway](https://github.com/bref/local-api-gateway). 
+
+This version provides Docker parallelisation, with the new `TARGET_CONTAINER` and `TARGET_HANDLER` variables as documented below.
+
+## Original content
+
 This project lets you run HTTP Lambda applications locally.
 
 ## Why

--- a/README.md
+++ b/README.md
@@ -87,9 +87,11 @@ services:
     volumes:
       - .:/var/task:ro
     environment:
-      TARGET: 'php:8080'
-      TARGET_CONTAINER: 'my-php-container' # if different to 'php' above
-      TARGET_HANDLER: '/path/to/vendor/bin/bref-local handler.php' # here, handler.php is in /var/task and bref-local is elsewhere
+      TARGET: 'php:8080' # service:port
+      TARGET_CONTAINER: 'my-php-container' # specify if different to the host within TARGET
+      TARGET_HANDLER: '/path/to/vendor/bin/bref-local handler.php' # The handler within /var/task; bref-local can be elsewhere
+      DEV_MAX_REQUESTS_IN_PARALLEL: 10 # number to run simultaneously
+      DEV_MAX_REQUESTS_IN_QUEUE: 20 # number to queue when capacity is reached
 ```
 
 ## Logging

--- a/package.json
+++ b/package.json
@@ -8,8 +8,10 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc && docker buildx build --load -t bref/local-api-gateway .",
+    "code-build": "tsc",
+    "docker-build": "docker buildx build --load -t bref/local-api-gateway .",
     "docker-publish": "npm run build && docker buildx build --push --platform linux/amd64,linux/arm64 -t bref/local-api-gateway .",
+    "build": "code-build && docker-build",
     "lint": "eslint .",
     "test": "vitest"
   },

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -35,6 +35,24 @@ const asyncSpawn = (command: string, args: string[]): Promise<{ stdout: string; 
 };
 
 /**
+ * Handles bref-local output headers
+ *
+ * The 'bref-local' handler returns the following header which needs to be stripped:
+ * v
+ * START
+ * END Duration ...
+ *
+ * ^
+ * (real output begins under this line)
+ *
+ * @param input
+ */
+function removeBrefLocalHeaders(input: string): string {
+    const match = input.match(/END Duration:.*\n([\s\S]*)/);
+    return match ? match[1].trim() : "";
+}
+
+/**
  * Runs the Docker Exec command
  *
  * @param container The docker container name (e.g. 'php')
@@ -69,18 +87,7 @@ export const runDockerCommand = async (container: string, handler: string, paylo
 
     // Strip header info from bref-local output
     if (handler?.includes('bref-local')) {
-        // The 'bref-local' handler returns the following header which needs to be stripped:
-        // v
-        // START
-        // END Duration ...
-        //
-        // ^
-        // (real output begins under this line)
-        //
-        result = result
-            .split('\n') // Split the output into lines
-            .slice(3)    // Skip the first three lines
-            .join('\n'); // Join the remaining lines back together
+        result = removeBrefLocalHeaders(result);
     }
 
     return result;

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -1,0 +1,87 @@
+import { spawn } from 'child_process';
+
+/**
+ * Utility function to promisify spawn
+ *
+ * @param command The command to run
+ * @param args The args as an array of strings
+ */
+const asyncSpawn = (command: string, args: string[]): Promise<{ stdout: string; stderr: string }> => {
+    return new Promise((resolve, reject) => {
+        const process = spawn(command, args);
+        let stdout = '';
+        let stderr = '';
+
+        process.stdout.on('data', (data) => {
+            stdout += data.toString();
+        });
+
+        process.stderr.on('data', (data) => {
+            stderr += data.toString();
+        });
+
+        process.on('close', (code) => {
+            if (code === 0) {
+                resolve({ stdout, stderr });
+            } else {
+                reject(new Error(`Command exited with code ${code}\nSTDOUT: ${stdout}\nSTDERR: ${stderr}`));
+            }
+        });
+
+        process.on('error', (err) => {
+            reject(err);
+        });
+    });
+};
+
+/**
+ * Runs the Docker Exec command
+ *
+ * @param container The docker container name (e.g. 'php')
+ * @param handler The handler command (e.g. '/path/to/vendor/bref/bref-local handler.php')
+ * @param payload The JSON-encoded payload
+ */
+export const runDockerCommand = async (container: string, handler: string, payload: string): Promise<string> => {
+    // Build the docker command: '/usr/bin/docker exec $CONTAINER $HANDLER $PAYLOAD' for spawn
+    const [command, ...handlerArgs] = handler.split(' ');
+    const dockerCommand = [
+        "exec",
+        container,
+        command,
+        ...handlerArgs,
+        payload,
+    ];
+
+    // Run the command and pull the output into a string
+    let result: string|null = null;
+    try {
+        const { stdout, stderr } = await asyncSpawn("/usr/bin/docker", dockerCommand);
+        if (stderr) {
+            console.info(`END [DOCKER] COMMAND: `, dockerCommand);
+            console.error(`END [DOCKER] STDERR: ${stderr}`);
+        }
+        result = Buffer.from(stdout).toString();
+    } catch (error) {
+        console.info(`END [DOCKER] COMMAND: `, dockerCommand);
+        console.error(`END [DOCKER] ERROR: ${(error as Error).message}`);
+        throw error;
+    }
+
+    // Strip header info from bref-local output
+    if (handler?.includes('bref-local')) {
+        // The 'bref-local' handler returns the following header which needs to be stripped:
+        // v
+        // START
+        // END Duration ...
+        //
+        // ^
+        // (real output begins under this line)
+        //
+        result = result
+            .split('\n') // Split the output into lines
+            .slice(3)    // Skip the first three lines
+            .join('\n'); // Join the remaining lines back together
+    }
+
+    return result;
+}


### PR DESCRIPTION
This PR adds support for concurrent execution of Bref.

This addresses https://github.com/brefphp/local-api-gateway/issues/15, but uses a different approach that discussed in that ticket.

This PR uses `docker exec` to run the `bref-local` CLI tool directly within the Bref PHP container, where it can run multiple processes concurrently. 

I've found the Docker approach is more robust than using Lambda RIE (and I was pushed to write it because Lambda RIE began crashing for me). It's also much, much faster. It does however move away from the AWS RIE tool and some folks may still want to use that, so i've left that code in place as a BC option for others.

I haven't worked on test automation as I'm not quite sure how's best to do this, plus I'm currently having troubles even getting this project's tests working on my machine (I think something's going on with node since an update in early 2025). Anyway, I'm happy to help work on this but I figure a collaboration with you is best if you want to incorporate this fork, plus I'm blocked right now in doing so.

I've put together a video to talk through the code and show a demo of it running: 
https://www.loom.com/share/a906c414a33c418993c34fe1a0d7ec1c
