### PR TITLE
Fix inline file upload

### DIFF
--- a/src/apiGateway.ts
+++ b/src/apiGateway.ts
@@ -35,7 +35,12 @@ export function httpRequestToEvent(request: Request): APIGatewayProxyEventV2 {
     );
 
     const bodyString = Buffer.isBuffer(request.body) ? request.body.toString('utf8') : '';
-    const shouldSendBase64 = request.method === 'GET' ? false : bodyString.includes('Content-Disposition: form-data');
+    const shouldSendBase64 = request.method === 'GET'
+        ? false
+        : (
+            bodyString.includes('Content-Disposition: form-data') ||
+            (headers['content-disposition']?.startsWith('inline;') === true)
+        );
 
     const cookies = request.headers.cookie ? request.headers.cookie.split('; ') : [];
 


### PR DESCRIPTION
Current version of `bref/local-api-gateway` supports only 'Content-Type: multipart/form-data',
whereas inline body (e.g. image/jpeg) is not encoded properly and the uploaded file is corrupted.

For example, the following request works:
```
PUT https://api.test/upload/profile-image
Content-Type: multipart/form-data;boundary="BoundaryDelimiter"
Accept: application/json

--BoundaryDelimiter
Content-Disposition: form-data; name="file"; filename="test.jpeg"
Content-Type: image/jpeg

< /home/images/test.jpeg
--BoundaryDelimiter--
```

, but this request doesn't work:
```
PUT https://api.test/upload/profile-image
Content-Type: image/jpeg
Accept: application/json
Content-Disposition: inline; filename="test.jpeg"

< /home/images/test.jpeg
```


Change in this PR resolves the issue.
